### PR TITLE
Fix Tcl script to make it independent on location of binaries.

### DIFF
--- a/ripcheck.tcl
+++ b/ripcheck.tcl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/tclsh8.6
+#!/usr/bin/tclsh
 
 # to use:
 #
@@ -418,7 +418,7 @@ proc DoFile {fname} {
 proc ctest {fname} {
 	# uncomment this if you don't have the ripcheckc program compiled for your platform
 	#return 1
-	set results [exec /m/admin/ripcheckc $fname 2>@1]
+	set results [exec ripcheckc $fname 2>@1]
 	puts -nonewline "Quick test: $fname"
 	if {[string first "everything ok" $results] == -1} {
 		puts "\n----\nFound potential WAV file CD ripping defects in\n$fname\nanalyzing further and making a GIF file of the problematic areas, with a corresponding TXT file.\n"


### PR DESCRIPTION
I wonder whether I have to add

``` tcl
package require Tcl 8.6                                                        
```

to the Tcl script. At least I tried with 8.5 (which is default on my RHEL-7) and it seems to be working just fine. Are you sure, it wouldn't work with 8.5?
